### PR TITLE
fix: 添加空的 subPackages 数组解决开发者工具报错

### DIFF
--- a/app.json
+++ b/app.json
@@ -29,5 +29,6 @@
   "requiredBackgroundModes": ["audio"],
   "useExtendedLib": {
     "weui": true
-  }
+  },
+  "subPackages": []
 }


### PR DESCRIPTION
- 解决 'Cannot read property subPackages of undefined' 错误
- 在 app.json 中显式声明空的 subPackages 数组